### PR TITLE
add option :trim_whitespace to parser

### DIFF
--- a/lib/eml/compiler.ex
+++ b/lib/eml/compiler.ex
@@ -205,10 +205,10 @@ defmodule Eml.Compiler do
     try do
       { :safe, concat(buffer, "", opts) }
     catch
-      :throw, { :illegal_quoted, stacktrace } ->
+      :throw, :illegal_quoted  ->
         reraise Eml.CompileError,
         [message: "It's only possible to pass assigns to templates or components when using &"],
-        stacktrace
+        System.stacktrace()
     end
   end
 
@@ -232,7 +232,7 @@ defmodule Eml.Compiler do
       { :safe, chunk } ->
         acc <> chunk
       _ ->
-        throw { :illegal_quoted, System.stacktrace() }
+        throw :illegal_quoted
     end
   end
 

--- a/lib/eml/compiler.ex
+++ b/lib/eml/compiler.ex
@@ -208,7 +208,7 @@ defmodule Eml.Compiler do
       :throw, :illegal_quoted  ->
         reraise Eml.CompileError,
         [message: "It's only possible to pass assigns to templates or components when using &"],
-        System.stacktrace()
+        __STACKTRACE__
     end
   end
 

--- a/lib/eml/element/generator.ex
+++ b/lib/eml/element/generator.ex
@@ -151,9 +151,9 @@ defmodule Eml.Element.Generator do
         { attrs, content }
     end
     case { content_or_attrs, maybe_content } do
-      { [{ :do, {:"__block__", _, content}}], _ }     -> init.(nil, content, in_match)
+      { [{ :do, {:__block__, _, content}}], _ }     -> init.(nil, content, in_match)
       { [{ :do, content}], _ }                        -> init.(nil, List.wrap(content), in_match)
-      { attrs, [{ :do, {:"__block__", _, content}}] } -> init.(attrs, content, in_match)
+      { attrs, [{ :do, {:__block__, _, content}}] } -> init.(attrs, content, in_match)
       { attrs, [{ :do, content}] }                    -> init.(attrs, List.wrap(content), in_match)
       { [{ _, _ } | _] = attrs, nil }                 -> init.(attrs, nil, in_match)
       { attrs, nil } when in_match                    -> init.(attrs, nil, in_match)

--- a/lib/eml/encoder.ex
+++ b/lib/eml/encoder.ex
@@ -69,6 +69,18 @@ defimpl Eml.Encoder, for: Tuple do
       raise Protocol.UndefinedError, protocol: Eml.Encoder, value: { :safe, data }
     end
   end
+
+  # for our use case we allow cdata to be included in the written HTML again, 
+  # since we only use Eml for parsing our own generated code, which must be 
+  # safe by other means already
+  def encode({ :cdata, data }) do
+    if is_binary(data) do
+      { :safe, data }
+    else
+      raise Protocol.UndefinedError, protocol: Eml.Encoder, value: { :safe, data }
+    end
+  end
+
   def encode(data) do
     if Macro.validate(data) == :ok do
       data

--- a/lib/eml/html/ldc_special_parser.ex
+++ b/lib/eml/html/ldc_special_parser.ex
@@ -1,0 +1,78 @@
+defmodule Eml.HTML.LDCSpecialParser do
+  def filter_empty_content(parsed_html) do
+    parsed_html
+      |> Enum.map(&filter_element/1)
+  end
+
+  defp filter_element(element) when is_binary(element), do: element
+  defp filter_element(%Eml.Element{} = element) do
+    filtered_content = element.content
+      |> filter_content()
+      |> case do
+        nil -> nil
+      [] -> element.content
+      [first_el | rest_content] -> 
+        filter_empty_content(nil, nil, first_el, rest_content, [])
+        |> Enum.reject(&is_nil/1)
+        |> Enum.reverse()
+      content when is_binary(content) -> content
+    end
+
+    %{element | content: filtered_content}
+  end
+
+  defp filter_content(nil), do: nil
+  defp filter_content(content) when is_list(content), do: Enum.map(content, &filter_element/1)
+  defp filter_content(content) when is_binary(content), do: maybe_trim_whitespace_content(content)
+
+
+  defp filter_empty_content(%Eml.Element{} = prev_el, this_el, %Eml.Element{} = next_el, more_content, acc) when is_binary(this_el) do
+    if String.starts_with?(to_string(prev_el.tag), "ldc") and String.starts_with?(to_string(next_el.tag), "ldc") do
+      acc = [prev_el | acc]
+
+      case more_content do 
+        [] -> 
+          [next_el | [this_el | acc]]
+        [more_el | rest_content]  -> 
+          # ensure that this_el is not trimmed in another call to filter_empty_content, so just skip it
+          filter_empty_content(nil, next_el, more_el, rest_content, [this_el | acc])
+      end
+    else
+      if String.trim(this_el) === "" do
+        case more_content do
+          [] -> 
+            [next_el | [prev_el | acc]]
+          [more_el | rest_content] -> 
+            filter_empty_content(prev_el, next_el, more_el, rest_content, acc)
+        end
+      else
+        case more_content do
+          [] -> 
+            [next_el | [this_el | [prev_el | acc]]]
+          [more_el | rest_content] -> 
+            acc = [prev_el | acc]
+            filter_empty_content(this_el, next_el, more_el, rest_content, acc)
+        end
+      end
+    end
+  end
+
+  defp filter_empty_content(prev_el, this_el, next_el, [], acc) do
+    prev_el = maybe_trim_whitespace_content(prev_el) 
+    this_el = maybe_trim_whitespace_content(this_el) 
+    next_el = maybe_trim_whitespace_content(next_el)
+
+    acc = if prev_el === "", do: acc, else: [prev_el | acc]
+    acc = if this_el === "", do: acc, else: [this_el | acc]
+    if next_el === "", do: acc, else: [next_el | acc]
+  end
+  defp filter_empty_content(prev_el, this_el, next_el, [more_el | rest_content], acc), do: 
+    filter_empty_content(this_el, next_el, more_el, rest_content, [maybe_trim_whitespace_content(prev_el) | acc])
+
+  defp maybe_trim_whitespace_content(content) when is_binary(content) do
+    trimmed = String.trim(content)
+    if trimmed === "", do: trimmed, else: content
+  end
+  defp maybe_trim_whitespace_content(element), do: element
+
+end

--- a/lib/eml/html/parser.ex
+++ b/lib/eml/html/parser.ex
@@ -6,9 +6,13 @@ defmodule Eml.HTML.Parser do
   @spec parse(binary, Keyword.t) :: [Eml.t]
   def parse(html, opts \\ []) do
     res = tokenize(html, { :blank, [] }, [], :blank, opts) |> parse_content(opts)
+
     case res do
       { content, [] } ->
-        content
+        app_default = Application.get_env(:eml, :remove_empty_content_between_non_ldc_tags, true)
+        remove_whitespace = Keyword.get(opts, :remove_empty_content_between_non_ldc_tags, app_default)
+
+        if remove_whitespace, do: Eml.HTML.LDCSpecialParser.filter_empty_content(content), else: content
       { content, rest }->
         raise Eml.ParseError, message: "Unparsable content, parsed: #{inspect content}, rest: #{inspect rest}"
     end

--- a/lib/eml/html/parser.ex
+++ b/lib/eml/html/parser.ex
@@ -240,7 +240,6 @@ defmodule Eml.HTML.Parser do
   defp empty?({ :blank, _ }, _opts), do: true
   defp empty?({ :content, content }, opts) do
     if get_trim_whitespace_opt(opts), do: String.trim(content) === "", else: false
-    # String.trim(content) === ""
   end
   defp empty?(_, _opts), do: false
 

--- a/lib/eml/html/parser.ex
+++ b/lib/eml/html/parser.ex
@@ -239,7 +239,8 @@ defmodule Eml.HTML.Parser do
   # Checks for empty content
   defp empty?({ :blank, _ }), do: true
   defp empty?({ :content, content }) do
-    String.trim(content) === ""
+    trim_whitespace = Application.get_env(:eml, :trim_whitespace, true)
+    if trim_whitespace, do: String.trim(content) === "", else: false
   end
   defp empty?(_), do: false
 


### PR DESCRIPTION
Two options for disabling whitespace trimming have been added:

1. Either pass trim_whitespace: false to Eml.parse() as an option
2. For app wide override set
     config :eml, trim_whitespace: false

If both variants are used, the option passed directly to the parser will
override the app wide config.

If no option is given, true will be used as the default value and thus
keep the old behavior.


Reason for the change: I've got an app where we receive user created html (in [froala](www.froala.com)) which we transform using Eml. However we sometimes got the problem that we've got spans in the html for the background color of some text, and currently Eml removes those whitespaces, something that is not expected by the end users. 

So we've created this fork which simply adds the two options above, would be nice if you could merge it so that we can remove our own fork.